### PR TITLE
Fix link to docs folder

### DIFF
--- a/docs/02-endpoints.md
+++ b/docs/02-endpoints.md
@@ -2,7 +2,7 @@
 
 ##  ER model
 
-Diagrams can be found in [docs folder](./docs).
+Diagrams can be found in [docs folder](./).
 
 - [XML version](./mx-elections-2021-db-er-diagram.xml) from [diagrams.net](diagrams.net)
 - [PNG version](./mx-elections-2021-db-er-diagram.png)


### PR DESCRIPTION
El enlace hacía referencia a la carpeta `docs `dentro del mismo directorio de `docs` por lo que te dirige a 'docs/docs' lo cual no existe.